### PR TITLE
Add requests on requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ urllib3
 argparse
 tabulate
 neotermcolor
+requests


### PR DESCRIPTION
Hi team,

  If the requests package is not included, the execution of the tool fails.

```
root@49e4fd2a9804:/LeakSearch# python3 LeakSearch.py -h
Traceback (most recent call last):
  File "/LeakSearch/LeakSearch.py", line 10, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
root@49e4fd2a9804:/LeakSearch#
```

## Reference

- https://github.com/JoelGMSec/LeakSearch/issues/2